### PR TITLE
GE-351 Allow custom widget ids; autoincrement by default

### DIFF
--- a/CheckfrontWidget.php
+++ b/CheckfrontWidget.php
@@ -59,6 +59,7 @@ class CheckfrontWidget
 	public $host= '';
 	public $src = '';
 	public $plugin_url = '';
+	private $nextDropletId = 1;
 
 
 	public $load_msg     = 'Searching Availability';
@@ -208,7 +209,9 @@ class CheckfrontWidget
 			$this->set_host($cnf['host']);
 		}
 
-		$cnf['widget_id'] = (isset($cnf['widget_id']) and $cnf['widget_id'] > 0) ? $cnf['widget_id'] : '01';
+		$cnf['widget_id'] = (isset($cnf['widget_id']) and $cnf['widget_id'] > 0)
+			? (int)$cnf['widget_id']
+			: $this->nextDropletId++;
 		$html = "\n<!-- CHECKFRONT BOOKING PLUGIN v{$this->interface_version}-->\n";
 		$html .= '<div id="CHECKFRONT_WIDGET_' . $cnf['widget_id'] . '"><p id="CHECKFRONT_LOADER" style="background: url(\'//' . $this->host . '/images/loader.gif\') left center no-repeat; padding: 5px 5px 5px 20px">' . $this->load_msg . '...</p></div>';
 		$html .= "\n<script type='text/javascript'>\nnew CHECKFRONT.Widget ({\n";

--- a/checkfront.php
+++ b/checkfront.php
@@ -35,6 +35,7 @@ function checkfront_func($cnf, $content=null)
 		'lang_id'    => '',
 		'partner_id' => '',
 		'popup'      => '',
+		'widget_id'  => '',
 	], $cnf);
 	return checkfront($cnf);
 }


### PR DESCRIPTION
This fixes being unable to use multiple `[checkfront]` shortcodes on one page.

The underlying droplet code supported custom `widget_id`'s, but it wasn't exposed as a shortcode parameter.

I've also changed the default widget_id from `"01"` to an auto-increment, so adding multiple shortcodes will naively just work without needing a custom widget_id.